### PR TITLE
volver al menu implementado

### DIFF
--- a/src/front_partida.py
+++ b/src/front_partida.py
@@ -161,6 +161,7 @@ def botones_display(truco_actual, se_puede_cantar_truco, se_puede_cantar_tantos,
 
     render_boton(PARTIDASURF, mazo_button_pos, 'Mazo')
     render_boton(PARTIDASURF, salir_button_pos, 'Salir')
+    render_boton(PARTIDASURF, volver_al_menu_button_pos, 'Volver al menu')
 
 def mostrar_cartel_turno(jugador_actual):
     pygame.draw.rect(PARTIDASURF, WHITE, turno_actual_cartel, border_radius=10)
@@ -286,8 +287,10 @@ def init_partida(nombre_p1, nombre_p2, max_puntos):
     }
     
     truco_music.play(50)
-
+    romper_while = False
     while True:
+        if romper_while:
+            break
         ganador = check_ganador(partida)
         if gano == True or ganador != None:
             puntos_display(p1, p2)
@@ -401,8 +404,15 @@ def init_partida(nombre_p1, nombre_p2, max_puntos):
                     gano_ronda = True
                 elif salir_button_pos.collidepoint(event.pos):
                     webbrowser.open('https://youtu.be/uHgt8giw1LY')
-                    
-                    return
+                elif volver_al_menu_button_pos.collidepoint(event.pos):
+                    #volver al menu principal
+                    #change screen to main menu
+                    #salir del loop del juego
+                    #como lo hago?
+                    from lobby_front import return_to_menu
+                    return_to_menu()
+                    romper_while = True
+                    break
                     
                 # Check botones de envido
                 if se_puede_cantar_tantos and envido_cantado:
@@ -523,6 +533,7 @@ def init_partida(nombre_p1, nombre_p2, max_puntos):
                 carta_seleccionada_surf.center = (pygame.mouse.get_pos()[0] - offset_x, pygame.mouse.get_pos()[1] - offset_y)
                
         pygame.display.update()
+    
 
 
 

--- a/src/lobby.py
+++ b/src/lobby.py
@@ -41,7 +41,7 @@ class Lobby():
         """
         if puntos not in [15, 30]: raise PuntosInvalidosError("Los puntos deben ser 15 o 30")
         self.puntos = puntos
-
+        
     def iniciar_partida(self) -> None:
         """
         Inicia una partida con los parametros seleccionados, para ello llama a una instancia

--- a/src/lobby_front.py
+++ b/src/lobby_front.py
@@ -70,6 +70,7 @@ class Screen:
         return self.running
 
     def stop(self):
+        print("dejo de correrse")
         self.running = False
 
     def click(self, event_pos):
@@ -79,7 +80,6 @@ class Screen:
 
     def display(self):
         self.pygame_screen.blit(fondo, (0, 0))
-
         for widget in self.widgets:
             widget.draw(self.pygame_screen)
         pygame.display.flip()
@@ -117,6 +117,8 @@ widgets_for_screen_3 = [
     play_game
 ]
 
+
+
 popup_button = Button(100, 100, 400, 100, (0, 255, 0), "Jugar", lambda: play_screen(screen))
 quit_button = Button(100, 250, 400, 100, (255, 0, 0), "Salir" , lambda: (screen.stop(), pygame.quit()))
 widgets_for_screen_1 = [quit_button, popup_button]
@@ -128,27 +130,37 @@ widgets_for_screen_2 = [hasta_15, hasta_30]
 
 screen = Screen(widgets_for_screen_1)
 
+def return_to_menu():
+    screen.change_widgets(widgets_for_screen_2)
+    truco_music.stop()
+    screen.starting = False
+    screen.running = True
+    screen.display()
+    
+
 
 def play_screen(screen):
     screen.change_widgets(widgets_for_screen_2)
 
 
-
 def lobby_main():
-    lobby_music.play()
-    while screen.is_running():
-        for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                pygame.quit()
-                return
-            if event.type == pygame.MOUSEBUTTONDOWN:
-                screen.click(event.pos)
-        if screen.is_running():
-            screen.display()
+    while True:
+        lobby_music.play()
+        while screen.is_running():
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    return
+                if event.type == pygame.MOUSEBUTTONDOWN:
+                    screen.click(event.pos)
+            if screen.is_running():
+                screen.display()
 
-    if (screen.starting == True):
-        lobby_music.stop()
-        screen.lobby.iniciar_partida()
+        if (screen.starting == True):
+            lobby_music.stop()
+            screen.lobby.iniciar_partida()
+
+        
 
 
 

--- a/src/pygame_objs.py
+++ b/src/pygame_objs.py
@@ -63,6 +63,8 @@ flor_button_pos = pygame.Rect(SCREEN_WIDTH*(1-1/5) - 10, SCREEN_HEIGHT/25 + 10 +
 mazo_button_pos = pygame.Rect(SCREEN_WIDTH*(1-1/5) - 10, SCREEN_HEIGHT/25 + 10 + 250, BUTTON_WIDTH, BUTTON_HEIGHT)
 salir_button_pos = pygame.Rect(SCREEN_WIDTH*(1-1/5) - 10, SCREEN_HEIGHT/25 + 10 + 300, BUTTON_WIDTH, BUTTON_HEIGHT)
 
+volver_al_menu_button_pos = pygame.Rect(SCREEN_WIDTH*(1-1/5) - 10, SCREEN_HEIGHT/25 + 10 + 350, BUTTON_WIDTH, BUTTON_HEIGHT)
+
 turno_actual_cartel = pygame.Rect(SCREEN_WIDTH/25, SCREEN_HEIGHT - BUTTON_HEIGHT, BUTTON_WIDTH*1.6, BUTTON_HEIGHT)
 
 # Botones Envido


### PR DESCRIPTION
## Motivation

Agregar un boton de volver al menu durante la partida

Closes #83 

## Summary of changes

Agregue un boton para volver al menu
al clickearla se llama return_to_menu() en lobby_front.py desde front_partida.py.

Agregue un while gigante que encierra todo el main del juego para que el juego se siga ejecutando a pesar de haber vuelto al menu.

## Test additions / changes

## Checklist
- [ x] Tested the changes locally.
- [ ] Reviewed the changes on GitHub, line by line.
- [ ] Unit tests added.
- [ x] This change requires new documentation.
  - [ ] Documentation has been added/updated.
